### PR TITLE
First-time caller

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -8,7 +8,7 @@ class GitUp
   def run
     get_repo
 
-    system "git fetch"
+    system('git', 'fetch', '--multiple', *@repo.remote_list)
     raise GitError, "`git fetch` failed" unless $? == 0
 
     with_stash do
@@ -61,8 +61,10 @@ class GitUp
   end
 
   def remote_for_branch(branch)
-    remote_name = @repo.config["branch.#{branch.name}.remote"] || "origin"
-    @repo.remotes.find { |r| r.name == "#{remote_name}/#{branch.name}" }
+    remote_name   = @repo.config["branch.#{branch.name}.remote"] || "origin"
+    remote_branch = @repo.config["branch.#{branch.name}.merge"]
+    remote_branch.gsub!(%r{refs/heads/}, '') if remote_branch
+    @repo.remotes.find { |r| r.name == "#{remote_name}/#{remote_branch}" }
   end
 
   def with_stash


### PR DESCRIPTION
Hey Aanand -

I've been using this for ages. Discovered two bugs recently:

a) it doesn't want to pull from all remotes by default. `git fetch` doesn't pull all, just the remote your current branch is tracking, so you could miss updates on master, say, if it has a different remote

b) "remote_for_branch" wasn't finding branches that weren't named _exactly_ like their local counterparts

I believe I have fixed these issues. And I didn't really write any tests either.
