### PR TITLE
Fetch all tracked repositories

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -8,7 +8,10 @@ class GitUp
   def run
     get_repo
 
-    system "git fetch"
+    remotes = @repo.branches.map {|b| remote_for_branch(b)}.
+      compact.map {|r| r.name.split('/', 2).first}.uniq
+
+    system('git', 'fetch', '--multiple', *remotes)
     raise GitError, "`git fetch` failed" unless $? == 0
 
     with_stash do


### PR DESCRIPTION
This causes git-up to fetch all remote repos that it intends to merge from, not just the current one, by mapping remote_for_branch across them all and taking the remote name portion.  Been using it for a few months now.
