### PR TITLE
re: git fetch --all

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -3,7 +3,8 @@ require 'grit'
 
 class GitUp
   def run
-    system "git", "fetch", "--all"
+    remotes = remote_map.values.map {|r| r.name.split('/', 2).first}.uniq
+    system('git', 'fetch', '--multiple', *remotes)
     raise GitError, "`git fetch` failed" unless $? == 0
 
     with_stash do


### PR DESCRIPTION
The issue with using "git fetch --all", rather than "--multiple" on a list of tracked remotes, is that there may be a significant number of remotes that are used for occasional pulls but not tracked by any branch.

For example, with Shopify, our rake+git environment creates remotes for _every_ other developer (for convenience), but I only track origin (mine) and mainline (our master repo).  "git fetch --all" is going to do 20 fetches, 18 of which are useless for the purposes of git-up.  (I'm actually surprised this didn't come up for Joshua.)

Thankfully, the new remote_map code made my original code much simpler, and this is the result.
