### PR TITLE
Flush remote_map cache after fetch

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -5,6 +5,7 @@ class GitUp
   def run
     system('git', 'fetch', '--multiple', *remotes)
     raise GitError, "`git fetch` failed" unless $? == 0
+    @remote_map = nil # flush cache after fetch
 
     with_stash do
       returning_to_current_branch do


### PR DESCRIPTION
A side effect of using the remote-map to influence the fetch is that it caches the Grit::Remote object, which also caches the commit info for that remote.  So the later git-up code behaves as if the fetch had never happened.

If e.g. master is the same as origin/master before the fetch, it will declare master to be up-to-date after the fetch, even if the fetch updates origin/master.   I had to run git-up twice to get proper behaviour.

The simplest solution seems to be to just clear the @remote_map cache after the fetch.  
