### PR TITLE
Added auto install of missing bundler gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ configuration
 As of `v0.4.1`, `git-up` can check your app for any new bundled gems and suggest a `bundle install` if necessary.
 
 It slows the process down slightly, and is therefore enabled by setting `GIT_UP_BUNDLER_CHECK='true'` in your `.bashrc`, `.profile`, or whatever.
+
+If you want git-up to auto-install missing gems, set `GIT_UP_BUNDLER_AUTOINSTALL='true'`.

--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -148,6 +148,7 @@ class GitUp
       Bundler.setup
     rescue Bundler::GemNotFound, Bundler::GitError
       puts 'Gems are missing.  You should `bundle install`.'.yellow
+      system('bundle install') if ENV['GIT_UP_BUNDLER_AUTOINSTALL'] == 'true'
     end
   end
 


### PR DESCRIPTION
I have added the ability to autoinstall missing gems if you set GIT_UP_BUNDLER_AUTOINSTALL=true.
