### PR TITLE
Added rebase arguments as a git config

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -132,7 +132,8 @@ class GitUp
   def rebase(target_branch)
     current_branch = repo.head
 
-    output, err = repo.git.sh("#{Grit::Git.git_binary} rebase #{target_branch.name}")
+    rebase_options = config("options.rebase")
+    output, err = repo.git.sh("#{Grit::Git.git_binary} rebase #{rebase_options} #{target_branch.name}")
 
     unless on_branch?(current_branch.name) and is_fast_forward?(current_branch, target_branch)
       raise GitError.new("Failed to rebase #{current_branch.name} onto #{target_branch.name}", output+err)


### PR DESCRIPTION
I wanted git-up to rebase by preserving merges...

So here is this small pull request allowing to specify rebase arguments using a git global (or local) config :

`git config --global git-up.options.rebase -p`

Thanks for git-up, I really like it, good work! :)
