### PR TITLE
Avoid conflicts with git-up's own dependencies when loading Gemfile.

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -145,6 +145,7 @@ class GitUp
     begin
       require 'bundler'
       ENV['BUNDLE_GEMFILE'] ||= File.expand_path('Gemfile')
+      Gem.loaded_specs.clear
       Bundler.setup
     rescue Bundler::GemNotFound, Bundler::GitError
       puts


### PR DESCRIPTION
```
lib/bundler/runtime.rb:31:in `block in setup': You have already activated diff-lcs 1.1.3, but your Gemfile requires diff-lcs 1.1.2. Consider using bundle exec. (Gem::LoadError)
```

The error happens when `git-up.bundler.check` is enabled and the application's Gemfile refers to an earlier version of a dependency which `git-up` it has has already loaded. In this case the `diff-lcs` dependency is via `cucumber`.

This patch fixes the error by clearing the loaded specs before loading the Gemfile. This would be a bad idea if we were going to then use the loaded Gemfile, but lucky for us we don't need to. An alternate fix would be to shell out to `bundle check` but this increases runtime by at least a second in my testing.
