### PR TITLE
After fetching, prune any deleted remote-tracking branches

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -3,7 +3,7 @@ require 'grit'
 
 class GitUp
   def run
-    system('git', 'fetch', '--multiple', *remotes)
+    system('git', 'fetch', '--multiple', '--prune', *remotes)
     raise GitError, "`git fetch` failed" unless $? == 0
     @remote_map = nil # flush cache after fetch
 


### PR DESCRIPTION
From the man file:

```
-p, --prune
  After fetching, remove any remote-tracking branches which no longer exist on the remote.
```
