### PR TITLE
Fixed Grit bug that caused stash weirdness

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -246,9 +246,9 @@ EOS
       diff_status   = repo.status
       actual_status = repo.git.status(:porcelain => true).split("\n").map {|l| l[3..-1]}
     
-      added         = Hash[diff_status.added.each_pair.select { |(x,y)| actual_status.include? x }]
-      changed       = Hash[diff_status.changed.each_pair.select { |(x,y)| actual_status.include? x }]
-      deleted       = Hash[diff_status.deleted.each_pair.select { |(x,y)| actual_status.include? x }]
+      added         = diff_status.added.select { |(x,y)| actual_status.include? x }
+      changed       = diff_status.changed.select { |(x,y)| actual_status.include? x }
+      deleted       = diff_status.deleted.select { |(x,y)| actual_status.include? x }
     
       added.length + changed.length + deleted.length
     end


### PR DESCRIPTION
This bug [https://github.com/mojombo/grit/pull/53] causes grit's status to sometimes report files have changed (as reported by git-diff-files) when they would not normally be considered to have changed (as repoted by, eg git-status).

Since it is unlikely that grit will fix this bug soon, this patch alters the way git-up checks for changes, filtering files reported by Grit#status by files reported by git-status.

This solves my local issues with git-up popping stash at random times.

/cc @wisq
