### PR TITLE
Some additional configuration knobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ By default, `git-up` will append the `--prune` flag to the `git fetch` command i
 
 Normally, `git-up` will only fetch remotes for which there is at least one local tracking branch. Setting this option will it `git-up` always fetch from all remotes, which is useful if e.g. you use a remote to push to your CI system but never check those branches out.
 
-### `git-up.log-hook "COMMAND"`
+### `git-up.rebase.log-hook "COMMAND"`
 
-Runs COMMAND every time a branch is updated, with the old head as $1 and the new head as $2. This can be used to view logs or diffs of incoming changes. For example: `'echo "changes on $1:"; git log --oneline --decorate $1..$2'`
+Runs COMMAND every time a branch is rebased or fast-forwarded, with the old head as $1 and the new head as $2. This can be used to view logs or diffs of incoming changes. For example: `'echo "changes on $1:"; git log --oneline --decorate $1..$2'`

--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -145,7 +145,7 @@ class GitUp
   end
 
   def log(branch, remote)
-    if log_hook = config("log-hook")
+    if log_hook = config("rebase.log-hook")
       system('sh', '-c', log_hook, 'git-up', branch.name, remote.name)
     end
   end


### PR DESCRIPTION
These are some options I've added to git-up for my own use. I hope you might find them useful. For fetch.all, I really do have a remote where I don't want to check out any tracking branches (and so git-up would normally not fetch it), but do want to keep updated. The other two are just deplay enhancements (while using the log-hook can generate messy output, I like being able to see commits as they come in).
