### PR TITLE
Simplify change_count to use just one git command.

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -243,14 +243,7 @@ EOS
 
   def change_count
     @change_count ||= begin
-      diff_status   = repo.status
-      actual_status = repo.git.status(:porcelain => true).split("\n").map {|l| l[3..-1]}
-    
-      added         = diff_status.added.select { |(x,y)| actual_status.include? x }
-      changed       = diff_status.changed.select { |(x,y)| actual_status.include? x }
-      deleted       = diff_status.deleted.select { |(x,y)| actual_status.include? x }
-    
-      added.length + changed.length + deleted.length
+      repo.git.status(:porcelain => true, :'untracked-files' => 'no').split("\n").count
     end
   end
 


### PR DESCRIPTION
This solves performance issues with grit's status method which
is very slow if a repository has many untracked files.

Example w/o patch:
`git-up  10,02s user 38,09s system 60% cpu 1:19,27 total`

Same repo w/patch:
`git-up  1,26s user 0,20s system 72% cpu 2,025 total`

This is taken from running `git up` in a repo with over a million untracked files.

Credit for this goes to @mbreit.
