### PR TITLE
Highlight the current branch during updating

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -89,7 +89,12 @@ BANNER
     branches.each do |branch|
       remote = remote_map[branch.name]
 
-      print branch.name.ljust(col_width)
+      curbranch = branch.name.ljust(col_width)
+      if branch.name == repo.head.name
+        print curbranch.bold
+      else
+        print curbranch
+      end
 
       if remote.commit.sha == branch.commit.sha
         puts "up to date".green


### PR DESCRIPTION
Hi Aanand.
I am a very fond user of your great git-up gem, and recommend it to many of my co-workers.
I mostly use it together with gitall (https://github.com/JKrag/gitall - forked from walterblaurock), on 10+ repos at once, so improving instant overview is very important to me.
I recently attempted mod'ing your git-up gem in order to highlight my current branch in the (sometimes long) list of branches it is updating.
I was pretty happy with the result, so I though I would submit it as a pull-request. I am not an expert ruby'ist, so you might know a cleaner way to code this, and I also haven't really investigated if this is a candidate for a configurable option - but for me at least it makes great sense as a default behaviour, and doesn't really disturb anything.
Regards Jan
