### PR TITLE
Fixed bug computing branches column width in empty repos.

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -92,7 +92,7 @@ BANNER
   end
 
   def rebase_all_branches
-    col_width = branches.map { |b| b.name.length }.max + 1
+    col_width = (branches.map { |b| b.name.length }.max || 0) + 1
 
     branches.each do |branch|
       remote = remote_map[branch.name]


### PR DESCRIPTION
After cloning empty repo and running git-up you will get an error.
