### PR TITLE
Enforce Ruby 1.9.2+ requirement

### DIFF
--- a/git-up.gemspec
+++ b/git-up.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.summary     = "git command to fetch and rebase all branches"
   s.license     = "MIT"
 
+  s.required_ruby_version = ">= 1.9.2"
+
   s.add_dependency "colored", ">= 1.2"
   s.add_dependency "grit"
   s.add_development_dependency "ronn"


### PR DESCRIPTION
I was just graced with a Ruby 1.8 project and learned the hard way that while git-up installs just fine under Ruby 1.8.7, posix-spawn 0.3.9 (itself a grit dependency) blows up.

This enforces a Ruby 1.9.2+ requirement. I checked that git-up does work on 1.9.2-p330 and 1.9.3-p547; 1.9.1-p431 doesn’t install for me on Ubuntu 14.04 and I don’t think Ruby 1.9.1 userbase size warrants further experiments.

Thanks so much for git-up!
