### PR TITLE
Add -d and -D options to git up command

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -99,12 +99,10 @@ BANNER
   end
 
   def rebase_all_branches(argv)
-    col_width = max_width
-
     branches.each do |branch|
       remote = remote_map[branch.name]
 
-      curbranch = branch.name.ljust(col_width)
+      curbranch = branch.name.ljust(max_width)
       if branch.name == repo.head.name
         print curbranch.bold
       else
@@ -386,9 +384,12 @@ EOS
   end
 
   def max_width
-    1 + (branches.map { |b| b.name.length } +
-         only_in_local_git_branches.map {|b| b.length }
-        ).max
+    @col_width ||= 1 + (branch_mapping).max
+  end
+
+  def branch_mapping
+    branches.map { |b| b.name.length } +
+      only_in_local_git_branches.map {|b| b.length }
   end
 end
 


### PR DESCRIPTION
When we merge changes and remove the remote branch, we need to manually remove the local branch. But if it is someone else that ships your code, you probably will need to remember that. Sometimes we simple try something in a exploratory branch, committing the changes for others to see some other option or maybe only to test a concept, in any of this, there's code on your branch that you maybe don't want to keep. 

This options serve that purpose: offer a tool so you don't need to remember stuff like that.
#### How it works

It gets all your local branches that don't have any correspondent remote branch and applies the option you passed to `git up`. 

Just like `git branch` `-d` and `-D` commands work, `-d` option removes branches only if they don't have any unmerged commits. 

`-D` removes the branch even if there is changes you didn't merge on master yet: use it **only** if you know what you are doing!

Your current branch will be preserved, even if you didn't push it yet. It will look like this: 
![screenshot 2015-07-20 22 11 14](https://cloud.githubusercontent.com/assets/2072707/8791093/4b45cda0-2f2c-11e5-9029-6d22f768bb6d.png)
