### PR TITLE
Fix repo dir detection under Git 2.5

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -147,7 +147,7 @@ BANNER
     repo_dir = `git rev-parse --git-common-dir`.chomp
 
     if $? == 0
-      if repo_dir == ".git"
+      if repo_dir == ".git"  || repo_dir == "--git-common-dir"
         repo_dir = `git rev-parse --show-toplevel`.chomp
         Dir.chdir repo_dir
       else

--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -144,10 +144,16 @@ BANNER
   end
 
   def get_repo
-    repo_dir = `git rev-parse --show-toplevel`.chomp
+    repo_dir = `git rev-parse --git-common-dir`.chomp
 
     if $? == 0
-      Dir.chdir repo_dir
+      if repo_dir == ".git"
+        repo_dir = `git rev-parse --show-toplevel`.chomp
+        Dir.chdir repo_dir
+      else
+        Dir.chdir repo_dir
+        Dir.chdir ".."
+      end
       @repo = Grit::Repo.new(repo_dir)
     else
       raise GitError, "We don't seem to be in a git repository."
@@ -352,4 +358,3 @@ EOS
     `git --version`[/\d+(\.\d+)+/]
   end
 end
-


### PR DESCRIPTION
When having more than one worktree on GIt 2.5, we have to use `git rev-parse --git-common-dir` command to get the correct, main repository `.git` directory (which may be unavailable under worktrees which are not the main one).

In contrast to `git rev-parse --show-toplevel`, which gives you the home of the _current_ worktree (which may **not** be the main one!), `git rev-parse --git-common-dir` will give you the full path to the `.git` dir in the original repository. 
Since it gives you the path to the `.git` dir, in order to get the _repo_ dir we have to backtrack one level up in order to be at the repository home.

Note that when in the main worktree, this command will output `.git` only; so in that case, we have to use the old way of detecting the git folder.

This should resolve the issue I posted earlier: #99 

_Little disclaimer: I am neither Git nor Ruby expert. I have checked this locally but it has to be checked 
a bit more thoroughly under various Git versions before merging, in my opinion._
