### PR TITLE
Quote git_binary so git-up doesn't fail when git path contains spaces.

### DIFF
--- a/lib/git-up.rb
+++ b/lib/git-up.rb
@@ -230,7 +230,7 @@ BANNER
     current_branch = repo.head
     arguments = config("rebase.arguments")
 
-    output, err = repo.git.sh("#{Grit::Git.git_binary} rebase #{arguments} #{target_branch.name}")
+    output, err = repo.git.sh("\"#{Grit::Git.git_binary}\" rebase #{arguments} #{target_branch.name}")
 
     unless on_branch?(current_branch.name) and is_fast_forward?(current_branch, target_branch)
       raise GitError.new("Failed to rebase #{current_branch.name} onto #{target_branch.name}", output+err)


### PR DESCRIPTION
This PR adds quoting around the git_binary when rebasing. I have multiple versions of Xcode installed and one was at /Applications/Xcode 6.4/  Grit picks up the version of git installed with Xcode and when the path contains spaces, rebasing fails. Quoting the binary path fixes this problem. 
