### PR TITLE
Add mention in Git 2.9 of config pull options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Accordingly, if you update to Git 2.9 or later, you can use this alias instead o
 
     git config --global alias.up 'pull --rebase --autostash'
 
+If you'd rather this happened on every `git pull`, then you can do this if you're running Git 2.9 or later:
+
+    git config --global pull.rebase true
+    git config --global rebase.autoStash true
+
 SYNOPSIS
 --------
 


### PR DESCRIPTION
I wanted to make a mention in the README that for `git pull` you can set this as a hard config. I know in the documentation mentions using the argument options for `git pull` for Git 2.9 and mentions how to create a Git alias appropriately to mimic the behavior of git-up, but I felt it was worth mentioning that there is a way to set it as a hard config for every `git pull` by doing

```
git config --global pull.rebase true
git config --global rebase.autoStash true
```

Feel free to close if you feel it's unnecessary